### PR TITLE
Add Hide future dates

### DIFF
--- a/src/component/DailyNoteEditorView.svelte
+++ b/src/component/DailyNoteEditorView.svelte
@@ -34,10 +34,18 @@
 
     $: if (hasMore && !hasFetch) {
         cacheDailyNotes = getAllDailyNotes();
-        // Build notes list by date in descending order.
-        for (const string of Object.keys(cacheDailyNotes).sort().reverse()) {
-            allDailyNotes.push(<TFile>cacheDailyNotes[string]);
+        const today = moment().startOf('day');
+        
+        const dateList = Object.keys(cacheDailyNotes).sort().reverse();
+        
+        const filteredDates = plugin.settings.hideUnreachedDates 
+            ? dateList.filter(date => moment(date, "YYYY-MM-DD").isSameOrBefore(today))
+            : dateList;
+            
+        for (const dateStr of filteredDates) {
+            allDailyNotes.push(<TFile>cacheDailyNotes[dateStr]);
         }
+        
         hasFetch = true;
         checkDailyNote();
     }

--- a/src/dailyNoteSettings.ts
+++ b/src/dailyNoteSettings.ts
@@ -4,11 +4,13 @@ import { App, debounce, PluginSettingTab, Setting } from "obsidian";
 export interface DailyNoteSettings {
     hideFrontmatter: boolean;
     hideBacklinks: boolean;
+    hideUnreachedDates: boolean;
 }
 
 export const DEFAULT_SETTINGS: DailyNoteSettings = {
     hideFrontmatter: false,
     hideBacklinks: false,
+    hideUnreachedDates: false,
 };
 
 
@@ -76,5 +78,14 @@ export class DailyNoteSettingTab extends PluginSettingTab {
                 })
             );
 
+        new Setting(containerEl)
+            .setName('Hide future dates')
+            .setDesc('Hide the diary entries for dates that have not yet arrived.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.hideUnreachedDates)
+                .onChange(async (value) => {
+                    this.plugin.settings.hideUnreachedDates = value;
+                    await this.plugin.saveSettings();
+                }));
     }
 }

--- a/src/dailyNoteViewIndex.ts
+++ b/src/dailyNoteViewIndex.ts
@@ -4,7 +4,7 @@ import {
     TFile,
     Workspace,
     WorkspaceContainer, WorkspaceItem,
-    WorkspaceLeaf, TAbstractFile, Scope
+    WorkspaceLeaf, TAbstractFile, Scope, App
 } from 'obsidian';
 import DailyNoteEditorView from "./component/DailyNoteEditorView.svelte";
 import { around } from "monkey-around";
@@ -12,6 +12,10 @@ import { DailyNoteEditor, isDailyNoteLeaf } from "./leafView";
 import "./style/index.css";
 import { addIconList } from "./utils/icon";
 import { DailyNoteSettings, DailyNoteSettingTab, DEFAULT_SETTINGS } from "./dailyNoteSettings";
+
+declare global {
+    var app: App;
+}
 
 export const DAILY_NOTE_VIEW_TYPE = "daily-note-editor-view";
 
@@ -236,5 +240,10 @@ export default class DailyNoteViewPlugin extends Plugin {
 
     async saveSettings() {
         await this.saveData(this.settings);
+        if (this.view?.view) {
+            this.view.view.hasFetch = false;
+            this.view.view.allDailyNotes = [];
+            this.view.view.renderedDailyNotes = [];
+        }
     }
 }

--- a/src/leafView.ts
+++ b/src/leafView.ts
@@ -18,11 +18,16 @@ import {
     WorkspaceLeaf,
     WorkspaceSplit,
     WorkspaceTabs,
+    App
 } from "obsidian";
 
 import type DailyNoteViewPlugin from "./dailyNoteViewIndex";
 import { genId } from "./utils/utils";
 
+// 添加全局 app 声明
+declare global {
+    var app: App;
+}
 
 export interface DailyNoteEditorParent {
     hoverPopover: DailyNoteEditor | null;
@@ -523,11 +528,11 @@ export class DailyNoteEditor extends nosuper(HoverPopover) {
         return leaf;
     }
 
-    buildState(parentMode: string, eState?: EphemeralState) {
+    buildState(parentMode: string, eState?: EphemeralState): OpenViewState {
         return {
-            active: false, // Don't let Obsidian force focus if we have autofocus off
-            state: {mode: "source"}, // Don't set any state for the view, because this leaf is stayed on another view.
-            eState: eState,
+            active: false,
+            state: {mode: "source"},
+            eState: eState as Record<string, unknown>
         };
     }
 

--- a/src/leafView.ts
+++ b/src/leafView.ts
@@ -24,7 +24,6 @@ import {
 import type DailyNoteViewPlugin from "./dailyNoteViewIndex";
 import { genId } from "./utils/utils";
 
-// 添加全局 app 声明
 declare global {
     var app: App;
 }


### PR DESCRIPTION
# Add option to hide future daily notes

## Description
Added a setting to hide future daily notes, inspired by Logseq's behavior. In Logseq, future journal entries are automatically hidden until their date arrives, which helps users focus on current and past content. This PR brings the same functionality to the Daily Notes Editor plugin.

## Changes
- Added `hideUnreachedDates` setting option
- Added toggle in settings tab
- Added date filtering based on current date
- Future daily notes will be hidden when the setting is enabled

## Implementation
Simple date comparison using moment.js to filter out future dates when the setting is enabled. The view automatically updates when the setting changes.
<img width="560" alt="截屏2025-02-08 下午4 19 50" src="https://github.com/user-attachments/assets/65415bea-93d9-4437-a1bf-96db92dea5dd" />
<img width="560" alt="截屏2025-02-08 下午4 19 20" src="https://github.com/user-attachments/assets/541d53b2-c8c5-487e-bede-3e61ab2193e1" />
<img width="560" alt="截屏2025-02-08 下午4 20 06" src="https://github.com/user-attachments/assets/f0821fef-f86c-44b9-9389-4cf6c3102333" />

---

Note: This code was generated with the assistance of AI (Claude). As I'm not very familiar with TypeScript, I would appreciate thorough code review to ensure quality and security. Any suggestions for improvements are welcome.