### PR TITLE
fix: reuse existing tab instead of opening new ones

### DIFF
--- a/src/dailyNoteViewIndex.ts
+++ b/src/dailyNoteViewIndex.ts
@@ -116,15 +116,12 @@ export default class DailyNoteViewPlugin extends Plugin {
     async openDailyNoteEditor() {
         const workspace = this.app.workspace;
 
-        // Check if a Daily Notes Editor view is already open
         const existingLeaves = workspace.getLeavesOfType(DAILY_NOTE_VIEW_TYPE);
         if (existingLeaves.length > 0) {
-            // Reuse the existing leaf
             workspace.revealLeaf(existingLeaves[0]);
             return;
         }
 
-        // Create a new leaf if none exists
         const leaf = workspace.getLeaf(true);
         await leaf.setViewState({ type: DAILY_NOTE_VIEW_TYPE });
         workspace.revealLeaf(leaf);

--- a/src/dailyNoteViewIndex.ts
+++ b/src/dailyNoteViewIndex.ts
@@ -115,6 +115,16 @@ export default class DailyNoteViewPlugin extends Plugin {
 
     async openDailyNoteEditor() {
         const workspace = this.app.workspace;
+
+        // Check if a Daily Notes Editor view is already open
+        const existingLeaves = workspace.getLeavesOfType(DAILY_NOTE_VIEW_TYPE);
+        if (existingLeaves.length > 0) {
+            // Reuse the existing leaf
+            workspace.revealLeaf(existingLeaves[0]);
+            return;
+        }
+
+        // Create a new leaf if none exists
         const leaf = workspace.getLeaf(true);
         await leaf.setViewState({ type: DAILY_NOTE_VIEW_TYPE });
         workspace.revealLeaf(leaf);


### PR DESCRIPTION
stops creating a new tab every time you click the ribbon or run the command. now it just focuses the existing tab if there's already one open.

fixes #65