### PR TITLE
Add autofocus and switch feature

### DIFF
--- a/src/component/DailyNote.svelte
+++ b/src/component/DailyNote.svelte
@@ -8,6 +8,7 @@
     export let plugin: DailyNoteViewPlugin;
     export let leaf: WorkspaceLeaf;
     export let shouldRender: boolean = true;
+    export let autoFocus: boolean = false;
 
     let editorEl: HTMLElement;
     let containerEl: HTMLElement;
@@ -101,6 +102,12 @@
                         editorHeight = actualHeight;
                         // Apply the height to the container
                         containerEl.style.minHeight = `${editorHeight}px`;
+
+                        if (autoFocus) {
+                            const editor = createdLeaf.view.editor;
+                            editor.focus();
+                            editor.setCursor(editor.lineCount(), 0);
+                        }
 
                         window.clearTimeout(timeout);
                     }

--- a/src/component/DailyNoteEditorView.svelte
+++ b/src/component/DailyNoteEditorView.svelte
@@ -3,6 +3,7 @@
     import type { WorkspaceLeaf } from "obsidian";
 
     import { TFile, moment } from "obsidian";
+    import { getDateFromFile } from "obsidian-daily-notes-interface";
     import DailyNote from "./DailyNote.svelte";
     import { inview } from "svelte-inview";
     import { TimeRange, SelectionMode, TimeField } from "../types/time";
@@ -261,6 +262,12 @@
         }
         visibleNotes = visibleNotes;
     }
+
+    function isToday(file: TFile): boolean {
+        if (!plugin.settings.autoFocus) return false;
+        const fileDate = getDateFromFile(file, "day");
+        return fileDate?.isSame(moment(), "day") ?? false;
+    }
 </script>
 
 <div class="daily-note-view">
@@ -289,6 +296,7 @@
                 plugin={plugin} 
                 leaf={leaf} 
                 shouldRender={visibleNotes.has(file.path)}
+                autoFocus={isToday(file)}
             />
         </div>
     {/each}

--- a/src/dailyNoteSettings.ts
+++ b/src/dailyNoteSettings.ts
@@ -7,6 +7,7 @@ export interface DailyNoteSettings {
     createAndOpenOnStartup: boolean;
     useArrowUpOrDownToNavigate: boolean;
     autoFocus: boolean;
+    switchToExisting: boolean;
 
     preset: {
         type: "folder" | "tag";
@@ -20,6 +21,7 @@ export const DEFAULT_SETTINGS: DailyNoteSettings = {
     createAndOpenOnStartup: false,
     useArrowUpOrDownToNavigate: false,
     autoFocus: false,
+    switchToExisting: false,
     preset: [],
 };
 
@@ -130,6 +132,20 @@ export class DailyNoteSettingTab extends PluginSettingTab {
                     .setValue(settings.autoFocus)
                     .onChange(async (value) => {
                         this.plugin.settings.autoFocus = value;
+                        this.applySettingsUpdate();
+                    })
+            );
+
+        new Setting(containerEl)
+            .setName("Switch to existing editor")
+            .setDesc(
+                "If an daily notes editor is already open, switch to it rather than open it on a new tab"
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(settings.switchToExisting)
+                    .onChange(async (value) => {
+                        this.plugin.settings.switchToExisting = value;
                         this.applySettingsUpdate();
                     })
             );

--- a/src/dailyNoteSettings.ts
+++ b/src/dailyNoteSettings.ts
@@ -6,6 +6,7 @@ export interface DailyNoteSettings {
     hideBacklinks: boolean;
     createAndOpenOnStartup: boolean;
     useArrowUpOrDownToNavigate: boolean;
+    autoFocus: boolean;
 
     preset: {
         type: "folder" | "tag";
@@ -18,6 +19,7 @@ export const DEFAULT_SETTINGS: DailyNoteSettings = {
     hideBacklinks: false,
     createAndOpenOnStartup: false,
     useArrowUpOrDownToNavigate: false,
+    autoFocus: false,
     preset: [],
 };
 
@@ -114,6 +116,20 @@ export class DailyNoteSettingTab extends PluginSettingTab {
                     .setValue(settings.useArrowUpOrDownToNavigate)
                     .onChange(async (value) => {
                         this.plugin.settings.useArrowUpOrDownToNavigate = value;
+                        this.applySettingsUpdate();
+                    })
+            );
+
+        new Setting(containerEl)
+            .setName("Auto focus today's note")
+            .setDesc(
+                "Automatically focus today's note and move the cursor to the end of the document"
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(settings.autoFocus)
+                    .onChange(async (value) => {
+                        this.plugin.settings.autoFocus = value;
                         this.applySettingsUpdate();
                     })
             );

--- a/src/dailyNoteViewIndex.ts
+++ b/src/dailyNoteViewIndex.ts
@@ -115,6 +115,15 @@ export default class DailyNoteViewPlugin extends Plugin {
 
     async openDailyNoteEditor() {
         const workspace = this.app.workspace;
+
+        if (this.settings.switchToExisting) {
+            const leaves = workspace.getLeavesOfType(DAILY_NOTE_VIEW_TYPE);
+            if (leaves.length > 0) {
+                workspace.revealLeaf(leaves[0]);
+                return;
+            }
+        }
+
         const leaf = workspace.getLeaf(true);
         await leaf.setViewState({ type: DAILY_NOTE_VIEW_TYPE });
         workspace.revealLeaf(leaf);


### PR DESCRIPTION
Added an option to auto focus todays note. Default is false, so nothing will change for current users. It allows you to start typing immediately when you open the daily notes editor.

<img width="1092" height="732" alt="image" src="https://github.com/user-attachments/assets/d32b14fb-20b1-4553-a66a-602b9899af4d" />
