### PR TITLE
fix: Remove iOS edge-fade mask on embedded editors

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -36,11 +36,33 @@
 
 .dn-editor .view-content {
     background: none !important;
+    -webkit-mask: none !important;
+    -webkit-mask-image: none !important;
+    mask: none !important;
+    mask-image: none !important;
+}
+
+.dn-editor .workspace-leaf-content {
+    -webkit-mask: none !important;
+    -webkit-mask-image: none !important;
+    mask: none !important;
+    mask-image: none !important;
+}
+
+.dn-editor .view-content::before,
+.dn-editor .view-content::after,
+.dn-editor .workspace-leaf-content::before,
+.dn-editor .workspace-leaf-content::after {
+    display: none !important;
 }
 
 .dn-editor .cm-scroller {
     padding: 0 !important;
     overflow-y: clip;
+    -webkit-mask: none !important;
+    -webkit-mask-image: none !important;
+    mask: none !important;
+    mask-image: none !important;
 }
 .daily-note-view .daily-note-wrapper::before {
     content: "";


### PR DESCRIPTION
## Summary

Obsidian applies `-webkit-mask-image` on `.view-content` and `.workspace-leaf-content` to create scroll edge-fade effects. In the embedded leaf structure used by Daily Notes Editor, this causes the first ~2 lines of each editor to render with progressively reduced brightness on iOS.

The fix disables masks and pseudo-element overlays on the embedded editor layers:
- `.dn-editor .view-content`
- `.dn-editor .workspace-leaf-content`
- `.dn-editor .cm-scroller`

This only affects the embedded editors inside the plugin, not Obsidian's normal views.

### Before / After (iOS)

Before: first lines are visibly dimmer, progressive fade from line 1 to ~line 3
<img width="660" height="1434" alt="Screenshot 2026-02-16 at 13 52 27" src="https://github.com/user-attachments/assets/3a1f0439-060b-4818-92f2-36005ae818de" />


After: all lines render at c
<img width="660" height="1434" alt="Screenshot 2026-02-16 at 14 03 13" src="https://github.com/user-attachments/assets/dc27f7fc-8d56-4d01-98fd-5ec9186253f2" />
onsistent brightness
